### PR TITLE
Change README.md example link to Blueprint skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To create a LightNCandy-based skin, you do the following:
    to the class name of your template class.
 3. Register your skin with the factory.
 
-For a full example, see [LivingStyleGuideSkin](https://github.com/werdnum/LivingStyleGuideSkin).
+For a full example, see the [Blueprint skin](https://github.com/wikimedia/mediawiki-skins-Blueprint).


### PR DESCRIPTION
Blueprint replaced LivingStyleGuideSkin, per [phab T93566](https://phabricator.wikimedia.org/T93566) "Rename LivingStyleGuide skin to Blueprint".
